### PR TITLE
Data quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 package.json
 package-lock.json
 myenv/
+data/test_stats.parquet

--- a/app/models/bracket_model.py
+++ b/app/models/bracket_model.py
@@ -190,7 +190,7 @@ class BracketSimulator:
         p = matchups["win probability"]
 
         # factor in path likelihoods
-        alpha = 1 # weighting of path odds vs win prob
+        alpha = 0 # weighting of path odds vs win prob
         adjusted_p = (p * (matchups["team1_path_odds"] ** alpha)) / (
             (p * (matchups["team1_path_odds"] ** alpha)) + ((1 - p) * (matchups["team2_path_odds"] ** alpha))
         )

--- a/app/utils/data_pipeline.py
+++ b/app/utils/data_pipeline.py
@@ -52,7 +52,7 @@ headers = ["DATE", "TYPE", "TEAM", "CONF.", "OPP.", "VENUE", "RESULT", "ADJ. O",
            "DREB%", "DFTR"]
 
 matchup_dfs = []
-years = range(2008, 2009)
+years = range(2008, 2026)
 years = [year for year in years if year != 2020]
 
 for year in years:
@@ -90,7 +90,6 @@ rs_matchups = rs_matchups.rename(columns={
 
 # filter out any games before 2008 (weird stuff with the website for early season games in 08)
 rs_matchups = rs_matchups[rs_matchups['exact_date'] > pd.Timestamp('2008-01-01')]
-rs_matchups = rs_matchups[rs_matchups['exact_date'] < pd.Timestamp('2008-01-05')]
 
 log_checkpoint("Pulled in all RS matchups")
 

--- a/app/utils/data_pipeline.py
+++ b/app/utils/data_pipeline.py
@@ -3,112 +3,47 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.chrome.options import Options
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from bs4 import BeautifulSoup
 import pandas as pd
+import polars as pl
+import numpy as np
+import duckdb
+from datetime import timedelta
 import ssl
 ssl._create_default_https_context = ssl._create_unverified_context
+import time
+start_time = time.time()
+import gc
+from threading import Lock # for progress tracking
+snapshot_printed_years = set()
+eos_printed_years = set()
+printed_lock = Lock()
+
+
+'''
+This code is a MESS. I will spend some time soon cleaning it up,
+but honestly there is not a lot of repeated operations to move to functions and
+there is just a lot that needs to be done. 
+It does work as is, but I will improve readability soon.
+'''
+
+chrome_options = Options()
+chrome_options.add_argument("--headless")  # Enable headless mode
+chrome_options.add_argument("--disable-gpu")  # Disable GPU usage 
+chrome_options.add_argument("--no-sandbox")  # Recommended for Docker 
+chrome_options.add_argument("--disable-dev-shm-usage")  # Reduce resource usage
+driver = webdriver.Chrome(options=chrome_options)
+
+# for tracking progress
+checkpoint_time = start_time
+def log_checkpoint(message):
+    global checkpoint_time
+    now = time.time()
+    print(f"{message} in {now - checkpoint_time:.2f}s")
+    checkpoint_time = now
 
 print("STARTING")
-
-# PULL IN TEAM STATS
-# headers for the DataFrame taken from the website (the csv file does not download headers so i add them manually)
-headers = ['', 'TEAM', 'ADJ OE', 'ADJ DE', 'BARTHAG', 'RECORD', 'WINS', 'GAMES', 'EFG', 'EFG D.', 
-           'FT RATE', 'FT RATE D', 'TOV%', 'TOV% D', 'O REB%', 'OP OREB%', 'RAW T', 
-           '2P %', '2P % D.', '3P %', '3P % D.', 'BLK %', 'BLKED %', 'AST %', 'OP AST %', 
-           '3P RATE', '3P RATE D', 'ADJ. T', 'AVG HGT.', 'EFF. HGT.', 'EXP.', 'YEAR', 
-           'PAKE', 'PASE', 'TALENT', '', 'FT%', 'OP. FT%', 'PPP OFF.', 'PPP DEF.', 
-           'ELITE SOS', 'TEAM']
-
-# loop through all the years, pull the data, and add them together
-dfs = []
-wabs = []
-years = range(2008, 2026)
-years = [year for year in years if year != 2020]
-for year in years:
-
-    # url of webpage containing data (type=R FOR REGULAR SEASON STATS ONLY, no data leakage)
-    url = f'https://barttorvik.com/team-tables_each.php?tvalue=All&year={year}&sort=&t2value=None&oppType=All&conlimit=All&top=0&quad=4&mingames=0&toprk=0&venue=All&type=R&yax=3'
-
-    # load the webpage using selenium driver and chrome
-    chrome_options = Options()
-    chrome_options.add_argument("--headless")  # Enable headless mode
-    chrome_options.add_argument("--disable-gpu")  # Disable GPU usage 
-    chrome_options.add_argument("--no-sandbox")  # Recommended for Docker 
-    chrome_options.add_argument("--disable-dev-shm-usage")  # Reduce resource usage
-    driver = webdriver.Chrome(options=chrome_options)
-    driver.get(url)
-
-    # wait for the table to appear on the page and get the source
-    team_table = WebDriverWait(driver, 10).until(
-            EC.presence_of_element_located((By.TAG_NAME, "table"))
-        )
-    page_source = driver.page_source
-
-    # parse the html content with BeautifulSoup and find the table
-    soup = BeautifulSoup(page_source, 'html.parser')
-    team_table = soup.find('table')
-
-    # check to make sure the table was found
-    if team_table:
-
-        # extract data from the table
-        data = []
-        rows = team_table.find_all('tr')
-            
-        # extract the rows
-        for row in rows[1:]:
-            cells = row.find_all('td')
-            row_data = [cell.get_text() for cell in cells]
-            data.append(row_data)
-            
-        # convert data to a pd df and add to the list of dfs
-        df = pd.DataFrame(data, columns=headers)
-        dfs.append(df)
-
-    else:
-        print('Team table not found on the webpage.')
-            
-    # close the webdriver
-    driver.quit()
-
-    ## read in another table for WAB stat (i have the csv urls so no scraping needed)
-    url = f'http://barttorvik.com/{year}_team_results.csv'
-    extras = pd.read_csv(url)
-    extras = extras.shift(axis=1)
-    extras.drop(columns=["rank"], inplace=True)  
-    wab_stats = extras[["team", "WAB"]]
-    wab_stats = wab_stats.rename(columns={"team" : "TEAM"}).copy()
-    wab_stats["YEAR"] = year
-    wabs.append(wab_stats)
-
-    print(f'Got all stats from {year}')
-
-print("Pulled in all stats")
-
-# concatenate the main stats DFs into a single DF
-combined_stats = pd.concat(dfs, ignore_index=True)
-combined_stats = combined_stats.T.drop_duplicates().T  # this should get rid of the second TEAM column
-
-# concatenate the wab stats dfs
-combined_wab = pd.concat(wabs, ignore_index=True)
-# some more processing on the main stats
-combined_stats = combined_stats.drop(columns=['']) # drop blank column
-combined_stats = combined_stats.replace(',', '', regex=True) # get rid of commas from cells
-numeric_columns = combined_stats.columns.difference(['TEAM', 'RECORD'])
-combined_stats.replace(r'^\s*$', 0, regex=True, inplace=True) # found blank cells under TALENT, so just make it zero
-combined_stats[numeric_columns] = combined_stats[numeric_columns].apply(pd.to_numeric) # convert everything to numeric
-
-# merge the wab with the main stats
-team_stats = pd.merge(combined_stats, combined_wab, on=["TEAM", "YEAR"], how="inner")
-
-# Calculate win percentage
-team_stats['win_percent'] = team_stats['WINS'] / team_stats['GAMES']
-
-
-# make new variable combining offensive and defensive efficiency
-team_stats['adjem'] = team_stats['ADJ OE'] - team_stats['ADJ DE']
-
-
 
 ## PULL IN REGULAR SEASON MATCHUPS
 
@@ -116,26 +51,33 @@ headers = ["DATE", "TYPE", "TEAM", "CONF.", "OPP.", "VENUE", "RESULT", "ADJ. O",
            "ADJ. D", "T", "OEFF", "OEFG%", "OTO%", "OREB%", "OFTR", "DEFF", "DEFG%", "DTO%", 
            "DREB%", "DFTR"]
 
-dfs = []
-years = range(2008, 2026)
+matchup_dfs = []
+years = range(2008, 2009)
 years = [year for year in years if year != 2020]
 
 for year in years:
+
+    print(f"Working on {year} regular season matchups")
     url = f"http://barttorvik.com/getgamestats.php?year={year}&csv=1"
     year_matchups = pd.read_csv(url)
     year_matchups = year_matchups.iloc[:, :20]
     year_matchups.columns = headers
-    dfs.append(year_matchups)
+    matchup_dfs.append(year_matchups)
 
 # concatenate the matchups into a single DF
-combined_matchups = pd.concat(dfs, ignore_index=True)
+combined_matchups = pd.concat(matchup_dfs, ignore_index=True)
+del matchup_dfs
+gc.collect()
 
 # drop tourney games because we already have those in another dataframe and order is important for those
 rs_matchups = combined_matchups[combined_matchups['TYPE'] != 3]
+del combined_matchups
+gc.collect()
 
 # Get only the variables I need. change some as needed
 rs_matchups = rs_matchups[["DATE", "TEAM", "OPP.", "RESULT"]]
 rs_matchups['RESULT'] = rs_matchups['RESULT'].str.contains('W') * 1
+rs_matchups['exact_date'] = pd.to_datetime(rs_matchups['DATE'], format='%m/%d/%y')
 rs_matchups['DATE'] = rs_matchups['DATE'].apply(lambda x: int(x.split('/')[-1]) + 2001 
                                                             if int(x.split('/')[-3]) > 8 
                                                             else int(x.split('/')[-1]) + 2000)
@@ -146,13 +88,368 @@ rs_matchups = rs_matchups.rename(columns={
     "RESULT": "winner"
 })
 
-print("Pulled in RS matchups")
+# filter out any games before 2008 (weird stuff with the website for early season games in 08)
+rs_matchups = rs_matchups[rs_matchups['exact_date'] > pd.Timestamp('2008-01-01')]
+rs_matchups = rs_matchups[rs_matchups['exact_date'] < pd.Timestamp('2008-01-05')]
+
+log_checkpoint("Pulled in all RS matchups")
+
+## PULL IN TEAM SNAPSHOTS
+
+# there are A LOT of snapshots to take, so parallelization speeds it up a bit
+
+def fetch_snapshot_data(row, headers, wab_headers):
+    year = row['year']
+    game_date = row['exact_date']
+
+    # track progress
+    with printed_lock:
+        if year not in snapshot_printed_years:
+            print(f"Working on {year} snapshots")
+            snapshot_printed_years.add(year)
+
+    begin_date = f"{year-1}1101"
+    end_date = (game_date - timedelta(days=1)).strftime("%Y%m%d")
+
+    snapshot_url = (
+        f"https://barttorvik.com/team-tables_each.php?tvalue=All&year={year}&sort=&t2value=None&oppType=All"
+        f"&conlimit=All&begin={begin_date}&end={end_date}&top=0&quad=4&mingames=0&toprk=0&venue=All&type=R&yax=3"
+    )
+    wab_url = (
+        f"https://barttorvik.com/?year={year}&sort=&hteam=&t2value=&conlimit=All&state=All"
+        f"&begin={begin_date}&end={end_date}&top=0&revquad=0&quad=5&venue=All&type=R&mingames=0#"
+    )
+    begin_date_mom = (game_date - timedelta(days=30)).strftime("%Y%m%d")
+    wab_mom_url = (
+        f"https://barttorvik.com/?year={year}&sort=&hteam=&t2value=&conlimit=All&state=All"
+        f"&begin={begin_date_mom}&end={end_date}&top=0&revquad=0&quad=5&venue=All&type=R&mingames=0#"
+    )
+
+    # retry logic
+    max_attempts = 3
+    attempt = 0
+    while attempt < max_attempts:
+        try:
+
+            # create a new driver for this attempt
+            driver = webdriver.Chrome(options=chrome_options)
+            
+            # snapshot table
+
+            driver.get(snapshot_url)
+            WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.TAG_NAME, "table")))
+            soup = BeautifulSoup(driver.page_source, 'html.parser')
+            team_table = soup.find('table')
+
+            snapshot_df = None
+            if team_table:
+                rows = team_table.find_all('tr')[1:]
+                data = [[cell.get_text() for cell in row.find_all('td')] for row in rows]
+                snapshot_df = pd.DataFrame(data, columns=headers)
+                snapshot_df['year'] = year
+                snapshot_df['exact_date'] = game_date
+
+            # wab table
+                
+            driver.get(wab_url)
+            WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.TAG_NAME, "table")))
+            wab_soup = BeautifulSoup(driver.page_source, 'html.parser')
+            wab_table = wab_soup.find('table')
+
+            wab_df = None
+            if wab_table:
+                rows = wab_table.find_all('tr')[1:]
+                data = [[cell.get_text() for cell in row.find_all('td')] for row in rows]
+                wab_df = pd.DataFrame(data, columns=wab_headers)
+                wab_df = wab_df[["TEAM", "WAB"]]
+                wab_df["YEAR"] = year
+                wab_df["exact_date"] = game_date
+
+            # momentum wab table
+                
+            driver.get(wab_mom_url)
+            WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.TAG_NAME, "table")))
+            mom_soup = BeautifulSoup(driver.page_source, 'html.parser')
+            mom_table = mom_soup.find('table')
+
+            mom_df = None
+            if mom_table:
+                rows = mom_table.find_all('tr')[1:]
+                data = [[cell.get_text() for cell in row.find_all('td')] for row in rows]
+                mom_df = pd.DataFrame(data, columns=wab_headers)
+                mom_df = mom_df[["TEAM", "WAB"]].rename(columns={"WAB": "recent_wab"})
+                mom_df["YEAR"] = year
+                mom_df["exact_date"] = game_date
+
+            # if all three parts succeeded, break out of the retry loop.
+            break
+
+        except Exception as e:
+            print(f"[ERROR] {year} {game_date} on attempt {attempt+1}")
+            attempt += 1
+            try:
+                driver.quit()
+            except Exception:
+                pass  # if quitting fails, ignore it
+            time.sleep(1)  # wait a second before retrying
+            if attempt == max_attempts:
+                print(f"Max attempts reached for {year} {game_date}. Returning None for all.")
+                snapshot_df, wab_df, mom_df = None, None, None
+                break
+        finally:
+            try:
+                driver.quit()
+            except Exception:
+                pass
+            gc.collect()
+
+    return (snapshot_df, wab_df, mom_df)
+
+# headers for the DataFrame taken from the website
+headers = ['', 'TEAM', 'ADJ OE', 'ADJ DE', 'BARTHAG', 'RECORD', 'WINS', 'GAMES', 'EFG', 'EFG D.', 
+           'FT RATE', 'FT RATE D', 'TOV%', 'TOV% D', 'O REB%', 'OP OREB%', 'RAW T', 
+           '2P %', '2P % D.', '3P %', '3P % D.', 'BLK %', 'BLKED %', 'AST %', 'OP AST %', 
+           '3P RATE', '3P RATE D', 'ADJ. T', 'AVG HGT.', 'EFF. HGT.', 'EXP.', 'YEAR', 
+           'PAKE', 'PASE', 'TALENT', '', 'FT%', 'OP. FT%', 'PPP OFF.', 'PPP DEF.', 
+           'ELITE SOS', 'TEAM']
+# define the headers for the WAB table (even tho we only want wab)
+wab_headers = ["Rk", "TEAM", "Conf", "G", "Rec", "AdjOE", "AdjDE", "Barthag", "EFG%", 
+                       "EFGD%", "TOR", "TORD", "ORB", "DRB", "FTR", "FTRD", "2P%","2P%D",
+                       "3P%","3P%D","3PR O","3PR D","Adj T.","WAB"]
+
+# get unique (year, exact_date) combinations from rs_matchups.
+unique_snapshots = rs_matchups[['year', 'exact_date']].drop_duplicates()
+
+snapshot_dfs = []
+matchup_wabs = []
+matchup_wabs_mom = []
+
+rows = unique_snapshots.to_dict("records")
+max_threads = min(8, len(rows)) 
+
+# do the threading
+with ThreadPoolExecutor(max_workers=max_threads) as executor:
+    futures = [executor.submit(fetch_snapshot_data, row, headers, wab_headers) for row in rows]
+
+    for future in as_completed(futures):
+        snapshot_df, wab_df, mom_df = future.result()
+        if snapshot_df is not None:
+            snapshot_dfs.append(snapshot_df)
+        if wab_df is not None:
+            matchup_wabs.append(wab_df)
+        if mom_df is not None:
+            matchup_wabs_mom.append(mom_df)
+
+log_checkpoint("Pulled in all matchup snapshots")
+
+# combine all snapshots into a single DataFrame
+team_stats_time_sensitive = pd.concat(snapshot_dfs, ignore_index=True)
+
+# concatenate the wab stats dfs
+combined_wab = pd.concat(matchup_wabs, ignore_index=True)
+
+# concatenate the momentum wab stats dfs
+combined_wab_mom = pd.concat(matchup_wabs_mom, ignore_index=True)
+
+del snapshot_dfs, matchup_wabs, matchup_wabs_mom, futures
+gc.collect()
+
+# some more processing on the main stats
+team_stats_time_sensitive = team_stats_time_sensitive.drop(columns=['']) # drop blank column
+team_stats_time_sensitive = team_stats_time_sensitive.replace(',', '', regex=True) # get rid of commas from cells
+numeric_columns = team_stats_time_sensitive.columns.difference(['TEAM', 'RECORD'])
+team_stats_time_sensitive.replace(r'^\s*$', 0, regex=True, inplace=True) # found blank cells under TALENT, so just make it zero
+team_stats_time_sensitive[numeric_columns] = team_stats_time_sensitive[numeric_columns].apply(pd.to_numeric) # convert everything to numeric
+
+# remove any duplicated column labels (keep the first occurrence)
+team_stats_time_sensitive = team_stats_time_sensitive.loc[:, ~team_stats_time_sensitive.columns.duplicated()]
+combined_wab = combined_wab.loc[:, ~combined_wab.columns.duplicated()]
+combined_wab_mom = combined_wab_mom.loc[:, ~combined_wab_mom.columns.duplicated()]
+
+# make sure types are correct and match
+team_stats_time_sensitive["YEAR"] = team_stats_time_sensitive["YEAR"].astype(int)
+team_stats_time_sensitive["exact_date"] = pd.to_datetime(team_stats_time_sensitive["exact_date"])
+combined_wab["YEAR"] = combined_wab["YEAR"].astype(int)
+combined_wab["exact_date"] = pd.to_datetime(combined_wab["exact_date"])
+combined_wab_mom["YEAR"] = combined_wab_mom["YEAR"].astype(int)
+combined_wab_mom["exact_date"] = pd.to_datetime(combined_wab_mom["exact_date"])
+combined_wab["WAB"] = pd.to_numeric(combined_wab["WAB"], errors='coerce')
+combined_wab_mom["recent_wab"] = pd.to_numeric(combined_wab_mom["recent_wab"], errors='coerce')
+combined_wab['TEAM'] = combined_wab['TEAM'].str.replace('\xa0', ' ')
+combined_wab['TEAM'] = combined_wab['TEAM'].str.extract(r'^(.+?)(?=\s+\d+\s+seed)', expand=False).fillna(combined_wab['TEAM']).str.strip()
+combined_wab_mom['TEAM'] = combined_wab_mom['TEAM'].str.replace('\xa0', ' ')
+combined_wab_mom['TEAM'] = combined_wab_mom['TEAM'].str.extract(r'^(.+?)(?=\s+\d+\s+seed)', expand=False).fillna(combined_wab_mom['TEAM']).str.strip()
+
+# merge the wab with the main stats
+rs_team_stats = pd.merge(team_stats_time_sensitive, combined_wab, on=["TEAM", "YEAR", "exact_date"], how="left")
+
+# merge the momentum WAB snapshot into team_stats
+rs_team_stats = pd.merge(rs_team_stats, combined_wab_mom, on=["TEAM", "YEAR", "exact_date"], how="left")
+
+del team_stats_time_sensitive, combined_wab, combined_wab_mom
+gc.collect()
+
+# calculate win percentage
+rs_team_stats['win_percent'] = rs_team_stats['WINS'] / rs_team_stats['GAMES']
+
+# make new variable combining offensive and defensive efficiency
+rs_team_stats['adjem'] = rs_team_stats['ADJ OE'] - rs_team_stats['ADJ DE']
+
+
+## PULL IN END OF SZN TEAM STATS
+# doing the same thing as above but stats for the whole regular season
+
+def fetch_end_of_season_data(year, headers, wab_headers, last_date):
+
+    # track progress
+    with printed_lock:
+        if year not in eos_printed_years:
+            print(f"Working on {year} end-of-season stats")
+            eos_printed_years.add(year)
+
+    max_attempts = 3
+    attempt = 0
+    while attempt < max_attempts:
+        try:
+
+            # create a new driver for this attempt
+            driver = webdriver.Chrome(options=chrome_options)
+            
+            # end of season snapshot 
+            eos_url = f"https://barttorvik.com/team-tables_each.php?tvalue=All&year={year}&sort=&t2value=None&oppType=All&conlimit=All&top=0&quad=4&mingames=0&toprk=0&venue=All&type=R&yax=3"
+            driver.get(eos_url)
+            WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.TAG_NAME, "table")))
+            soup = BeautifulSoup(driver.page_source, 'html.parser')
+            eos_table = soup.find('table')
+            eos_df = None
+            if eos_table:
+                rows = eos_table.find_all('tr')[1:]
+                data = [[cell.get_text() for cell in row.find_all('td')] for row in rows]
+                eos_df = pd.DataFrame(data, columns=headers)
+                eos_df["YEAR"] = year
+
+            # full season wab
+                
+            wab_url = f"https://barttorvik.com/?year={year}&sort=&hteam=&t2value=&conlimit=All&state=All&top=0&revquad=0&quad=5&venue=All&type=R&mingames=0#"
+            driver.get(wab_url)
+            WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.TAG_NAME, "table")))
+            wab_soup = BeautifulSoup(driver.page_source, 'html.parser')
+            wab_table = wab_soup.find('table')
+            wab_df = None
+            if wab_table:
+                rows = wab_table.find_all('tr')[1:]
+                data = [[cell.get_text() for cell in row.find_all('td')] for row in rows]
+                wab_df = pd.DataFrame(data, columns=wab_headers)[["TEAM", "WAB"]]
+                wab_df["YEAR"] = year
+
+            # momentum wab heading into tourney
+                
+            begin_date_mom = (last_date - timedelta(days=30)).strftime("%Y%m%d")
+            wab_mom_url = f"https://barttorvik.com/?year={year}&sort=&begin={begin_date_mom}&top=0&revquad=0&quad=5&venue=All&type=R&mingames=0#"
+            driver.get(wab_mom_url)
+            WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.TAG_NAME, "table")))
+            mom_soup = BeautifulSoup(driver.page_source, 'html.parser')
+            mom_table = mom_soup.find('table')
+            mom_df = None
+            if mom_table:
+                rows = mom_table.find_all('tr')[1:]
+                data = [[cell.get_text() for cell in row.find_all('td')] for row in rows]
+                mom_df = pd.DataFrame(data, columns=wab_headers)[["TEAM", "WAB"]]
+                mom_df = mom_df.rename(columns={"WAB": "recent_wab"})
+                mom_df["YEAR"] = year
+
+            # if everything worked, break out of the loop
+            break
+
+        except Exception as e:
+            print(f"[EOS ERROR] {year} on attempt {attempt+1}")
+            attempt += 1
+            try:
+                driver.quit()
+            except Exception:
+                pass
+            time.sleep(1)  # wait before retrying 
+            if attempt == max_attempts:
+                print(f"Max attempts reached for {year}.")
+                eos_df, wab_df, mom_df = None, None, None
+                break
+        finally:
+            try:
+                driver.quit()
+            except Exception:
+                pass
+            gc.collect()
+        
+    return (eos_df, wab_df, mom_df)
+
+
+eos_futures = []
+eos_years = rs_matchups['year'].unique()
+last_dates = rs_matchups.groupby('year')['exact_date'].max().to_dict()
+
+with ThreadPoolExecutor(max_workers=len(eos_years)) as executor:
+    for year in eos_years:
+        eos_futures.append(
+            executor.submit(fetch_end_of_season_data, year, headers, wab_headers, last_dates[year])
+        )
+
+eos_dfs, eos_wabs, eos_wabs_mom = [], [], []
+
+for future in as_completed(eos_futures):
+    eos_df, eos_wab, eos_mom = future.result()
+    if eos_df is not None:
+        eos_dfs.append(eos_df)
+    if eos_wab is not None:
+        eos_wabs.append(eos_wab)
+    if eos_mom is not None:
+        eos_wabs_mom.append(eos_mom)
+
+log_checkpoint("Pulled in all end-of-season stats")
+
+combined_eos_stats = pd.concat(eos_dfs, ignore_index=True)
+combined_eos_wabs = pd.concat(eos_wabs, ignore_index=True)
+combined_eos_wab_moms = pd.concat(eos_wabs_mom, ignore_index=True)
+del eos_dfs, eos_wabs, eos_wabs_mom, eos_futures
+gc.collect()
+
+combined_eos_stats = combined_eos_stats.drop(columns=['']) # drop blank column
+combined_eos_stats = combined_eos_stats.replace(',', '', regex=True) # get rid of commas from cells
+numeric_columns = combined_eos_stats.columns.difference(['TEAM', 'RECORD'])
+combined_eos_stats.replace(r'^\s*$', 0, regex=True, inplace=True) # found blank cells under TALENT, so just make it zero
+combined_eos_stats[numeric_columns] = combined_eos_stats[numeric_columns].apply(pd.to_numeric) # convert everything to numeric
+
+combined_eos_stats = combined_eos_stats.loc[:, ~combined_eos_stats.columns.duplicated()]
+combined_eos_wabs = combined_eos_wabs.loc[:, ~combined_eos_wabs.columns.duplicated()]
+combined_eos_wab_moms = combined_eos_wab_moms.loc[:, ~combined_eos_wab_moms.columns.duplicated()]
+
+combined_eos_stats["YEAR"] = combined_eos_stats["YEAR"].astype(int)
+combined_eos_wabs["YEAR"] = combined_eos_wabs["YEAR"].astype(int)
+combined_eos_wab_moms["YEAR"] = combined_eos_wab_moms["YEAR"].astype(int)
+combined_eos_wabs["WAB"] = pd.to_numeric(combined_eos_wabs["WAB"], errors='coerce')
+combined_eos_wab_moms["recent_wab"] = pd.to_numeric(combined_eos_wab_moms["recent_wab"], errors='coerce')
+combined_eos_wabs['TEAM'] = combined_eos_wabs['TEAM'].str.replace('\xa0', ' ')
+combined_eos_wabs['TEAM'] = combined_eos_wabs['TEAM'].str.extract(r'^(.+?)(?=\s+\d+\s+seed)', expand=False).fillna(combined_eos_wabs['TEAM']).str.strip()
+combined_eos_wab_moms['TEAM'] = combined_eos_wab_moms['TEAM'].str.replace('\xa0', ' ')
+combined_eos_wab_moms['TEAM'] = combined_eos_wab_moms['TEAM'].str.extract(r'^(.+?)(?=\s+\d+\s+seed)', expand=False).fillna(combined_eos_wab_moms['TEAM']).str.strip()
+
+eos_team_stats = pd.merge(combined_eos_stats, combined_eos_wabs, on=["TEAM", "YEAR"], how="left")
+eos_team_stats = pd.merge(eos_team_stats, combined_eos_wab_moms, on=["TEAM", "YEAR"], how="left")
+
+del combined_eos_stats, combined_eos_wabs, combined_eos_wab_moms
+gc.collect()
+
+eos_team_stats['win_percent'] = eos_team_stats['WINS'] / eos_team_stats['GAMES']
+eos_team_stats['adjem'] = eos_team_stats['ADJ OE'] - eos_team_stats['ADJ DE']
+
 
 # READ IN TOURNAMENT MATCHUP DATA
 tournament_matchups = pd.read_csv("data/tournament_matchups.csv")
+tournament_matchups = tournament_matchups[tournament_matchups["YEAR"].isin(years)]
 
 # MERGE TOURNAMENT MATCHUPS WITH STATS
-tourney_team_stats = pd.merge(tournament_matchups, team_stats, on=["TEAM", "YEAR"], how='left')
+tourney_team_stats = pd.merge(tournament_matchups, eos_team_stats, on=["TEAM", "YEAR"], how='left')
+del tournament_matchups
+gc.collect()
 
 # use the same processing steps as before (combine rows, rename + drop columns)
 tourney_matchup_stats = pd.DataFrame(columns=['year', 'team_1', 'seed_1', 'round_1', 'current_round', 'score_1',
@@ -178,6 +475,7 @@ for i in range(0, len(tourney_team_stats), 2):
             'badj_o_1': team1_info['ADJ OE'],
             'badj_d_1': team1_info['ADJ DE'],
             'wab_1': team1_info['WAB'],
+            'recent_wab_1': team1_info['recent_wab'],
             'barthag_1': team1_info['BARTHAG'],
             'efg_1': team1_info['EFG'],
             'efg_d_1': team1_info['EFG D.'],
@@ -206,6 +504,7 @@ for i in range(0, len(tourney_team_stats), 2):
             'badj_o_2': team2_info['ADJ OE'],
             'badj_d_2': team2_info['ADJ DE'],
             'wab_2': team2_info['WAB'],
+            'recent_wab_2': team2_info['recent_wab'],
             'barthag_2': team2_info['BARTHAG'],
             'efg_2': team2_info['EFG'],
             'efg_d_2': team2_info['EFG D.'],
@@ -239,12 +538,12 @@ tourney_matchup_stats = pd.concat([tourney_matchup_stats, pd.DataFrame(matchup_i
 tourney_matchup_stats["winner"] = 1 * (tourney_matchup_stats["score_1"] > tourney_matchup_stats["score_2"])
 tourney_matchup_stats.drop(columns=["score_1", "score_2"], inplace=True)
 
-print("Tourney matchups + stats")
+log_checkpoint("Tourney matchups + stats done")
 
 # MERGE REGULAR SEASON MATCHUPS WITH STATS
 
 # change names in team_stats to match format of names in rs_matchups
-team_stats = team_stats.rename(columns={
+rs_team_stats = rs_team_stats.rename(columns={
     'YEAR': 'year',
     'TEAM': 'team',
     'adjem' : 'badj_em',
@@ -277,20 +576,43 @@ team_stats = team_stats.rename(columns={
     'win_percent': 'win_percent'
 })
 
-rs_matchups_with_stats = pd.merge(rs_matchups, team_stats, left_on=['team_1', 'year'], 
-                                  right_on=['team', 'year'], how='left')
-rs_matchups_with_stats.rename(columns=lambda x: x + '_1' if x not in ['team_1', 'team_2', 'year', 'winner'] 
-                              else x, inplace=True)
+rs_team_stats = rs_team_stats.loc[:, ~rs_team_stats.columns.duplicated()]
+rs_matchups = rs_matchups.loc[:, ~rs_matchups.columns.duplicated()]
 
-print("Add team 1 stats to RS matchups")
+# merge the matchups with the stats
+## use duckdb for merge because pandas is too slow
+## i would like to do this throughout the pipeline, but this is the current bottleneck
 
-rs_matchups_with_stats = pd.merge(rs_matchups_with_stats, team_stats, left_on=['team_2', 'year'], 
-                                  right_on=['team', 'year'], how='left')
-rs_matchups_with_stats.rename(columns=lambda x: x + '_2' if x not in ['team_1', 'team_2', 'year', 'winner'] 
-                              and not x.endswith('_1') 
-                              else x, inplace=True)
+con = duckdb.connect()
+con.register("matchups", rs_matchups)
+con.register("stats", rs_team_stats)
 
-print("Add team 2 stats to RS matchups")
+# sql join
+query = """
+    SELECT 
+        m.*,
+        {team1_cols},
+        {team2_cols}
+    FROM matchups m
+    LEFT JOIN stats s1
+        ON m.team_1 = s1.team AND m.year = s1.year AND m.exact_date = s1.exact_date
+    LEFT JOIN stats s2
+        ON m.team_2 = s2.team AND m.year = s2.year AND m.exact_date = s2.exact_date
+"""
+
+# build prefixed columns for each join
+all_cols = [col for col in rs_team_stats.columns if col not in ['team', 'year', 'exact_date']]
+team1_cols = ", ".join([f"s1.\"{col}\" AS \"{col}_1\"" for col in all_cols])
+team2_cols = ", ".join([f"s2.\"{col}\" AS \"{col}_2\"" for col in all_cols])
+
+# format into the sql query
+full_query = query.format(team1_cols=team1_cols, team2_cols=team2_cols)
+
+# now run it
+rs_matchups_with_stats = con.execute(full_query).df()
+con.close()
+
+log_checkpoint("Added all team stats to RS matchups")
 
 filtered_columns = [col for col in rs_matchups_with_stats.columns if col.islower()]
 rs_matchups_with_stats = rs_matchups_with_stats[filtered_columns]
@@ -298,7 +620,7 @@ rs_matchups_with_stats = rs_matchups_with_stats[filtered_columns]
 rs_matchups_with_stats.columns = ['year' if 'year' in col else col for col in rs_matchups_with_stats.columns]
 rs_matchups_with_stats = rs_matchups_with_stats.loc[:,~rs_matchups_with_stats.columns.duplicated()].copy()
 
-print("Remove unwanted columns from RS matchups")
+log_checkpoint("Remove unwanted columns from RS matchups")
 
 # create a unique matchup id so i can drop the rows that are the same as others but with team_1 and team_2 flipped
 # (make sure to not drop matchups that actually happened twice. duplicates are always next to each other)
@@ -308,21 +630,75 @@ rs_matchups_with_stats["matchup_id"] = rs_matchups_with_stats.apply(lambda row: 
 duplicate_mask = rs_matchups_with_stats["matchup_id"].eq(rs_matchups_with_stats["matchup_id"].shift())
 non_consecutive_duplicates_mask = ~duplicate_mask
 rs_matchups_with_stats = rs_matchups_with_stats[non_consecutive_duplicates_mask]
-print("Add matchup id to RS data and drop duplicate games")
+
+log_checkpoint("Added matchup id to RS data and drop duplicate games")
+
+## BALANCE/SHUFFLE RS MATCHUPS 
+# order matters for tourney games, so leave that alone
+
+# randomly flip teams to reduce bias
+np.random.seed(44)
+flip_mask = np.random.rand(len(rs_matchups_with_stats)) < 0.5
+flipped = rs_matchups_with_stats[flip_mask].copy()
+non_flipped = rs_matchups_with_stats[~flip_mask].copy()
+swap_columns = ['team_1', 'team_2', 'winner'] + [
+    col for col in rs_matchups_with_stats.columns if col.endswith('_1') or col.endswith('_2')
+]
+for col in swap_columns:
+    if col.endswith('_1'):
+        twin = col.replace('_1', '_2')
+        flipped[col], flipped[twin] = rs_matchups_with_stats.loc[flip_mask, twin], rs_matchups_with_stats.loc[flip_mask, col]
+    elif col == 'team_1':
+        flipped['team_1'], flipped['team_2'] = rs_matchups_with_stats.loc[flip_mask, 'team_2'], rs_matchups_with_stats.loc[flip_mask, 'team_1']
+    elif col == 'winner':
+        flipped['winner'] = 1 - rs_matchups_with_stats.loc[flip_mask, 'winner']
+
+# combine back
+rs_matchups_with_stats = pd.concat([flipped, non_flipped], ignore_index=True)
+
+# enforce perfect balance of winner column
+num_total = len(rs_matchups_with_stats)
+num_to_flip = abs(rs_matchups_with_stats['winner'].sum() - num_total // 2)
+
+# flip enough rows with excess winner value
+if num_to_flip > 0:
+    overrepresented_val = int(rs_matchups_with_stats['winner'].mean() > 0.5)
+    to_correct = rs_matchups_with_stats[rs_matchups_with_stats['winner'] == overrepresented_val].sample(n=num_to_flip, random_state=42)
+    corrected = to_correct.copy()
+
+    for col in swap_columns:
+        if col.endswith('_1'):
+            twin = col.replace('_1', '_2')
+            corrected[col], corrected[twin] = to_correct[twin], to_correct[col]
+        elif col == 'team_1':
+            corrected['team_1'], corrected['team_2'] = to_correct['team_2'], to_correct['team_1']
+        elif col == 'winner':
+            corrected['winner'] = 1 - to_correct['winner']
+
+    # replace those rows
+    rs_matchups_with_stats = rs_matchups_with_stats.drop(to_correct.index)
+    rs_matchups_with_stats = pd.concat([rs_matchups_with_stats, corrected], ignore_index=True)
+
+# final check
+print("\nPost shuffle + correction check:")
+print(rs_matchups_with_stats['winner'].value_counts(normalize=True))
+print('\n')
 
 # add a column to each data set (tourney and regular season) to differentiate them post-merge
 tourney_matchup_stats["type"] = "T" # tournament
 rs_matchups_with_stats["type"] = "RS" # regular season
 
+## COMBINE TOURNEY AND REGULAR SEASON MATCHUPS
+
 all_matchup_stats = pd.concat([tourney_matchup_stats, rs_matchups_with_stats], ignore_index=True)
+del tourney_matchup_stats, rs_matchups_with_stats
+gc.collect()
 
-print("add rs_matchups under tourney matchups")
-
-
+log_checkpoint("Added rs_matchups under tourney matchups")
 
 # get the stat differences same as before
 stat_variables = [
-    'badj_em', 'badj_o', 'badj_d', 'wab', 'barthag', 'efg', 'efg_d', 'ft_rate', 'ft_rate_d', 'tov_percent',
+    'badj_em', 'badj_o', 'badj_d', 'wab', 'recent_wab', 'barthag', 'efg', 'efg_d', 'ft_rate', 'ft_rate_d', 'tov_percent',
     'tov_percent_d', 'adj_tempo', '3p_percent', '3p_rate', '3p_percent_d', '2p_percent', '2p_percent_d', 
     'o_reb_percent', 'op_o_reb_percent', 'blk_percent', 'ast_percent', 'pppo', 'pppd',
     'exp', 'eff_hgt', 'talent', 'elite_sos', 'win_percent'
@@ -340,13 +716,19 @@ for variable in stat_variables:
 
 # Concatenate the stat difference DataFrame with the existing DataFrame
 all_matchup_stats = pd.concat([all_matchup_stats, stat_diff_df], axis=1)
+del stat_diff_df
+gc.collect()
 
 # Add close call flags (only used for simulation strategy)
-all_matchup_stats['close_call_1'] = False
-all_matchup_stats['close_call_2'] = False
+new_flags = pd.DataFrame({
+    'close_call_1': False,
+    'close_call_2': False
+}, index=all_matchup_stats.index)
+all_matchup_stats = pd.concat([all_matchup_stats, new_flags], axis=1)
 
 # EXPORT DF
 directory = "data"
 all_matchup_stats.to_parquet(directory + "/all_matchup_stats.parquet", index=False)
 
-print("Finish")
+end_time = time.time()
+print("\nTotal Elapsed time: {:.2f} seconds\n".format(end_time - start_time))


### PR DESCRIPTION
Improved data quality by updated data_pipeline.py

#### Main Additions

- snapshots in time at each regular season game for all stats (rather than using end of szn stats for all games)
- added recent_wab representing the 'wins above bubble' for the last month for each team. using as a sort of momentum stat: how well each team is currently performing. 

#### Challenges

- takes much more time to run data pipeline now. used to be a couple minutes. now anywhere from a couple to several hours depending on web driver performance
- caused by new snapshots of data being required for each team every day where games occur, instead of just once per year
- parallelized the snapshot grabs. makes it faster, but sometimes overloads the website and fails at pulling some data. usually not an issue, but may need to run the pipeline again if it starts to feel frequently. 

#### Extra

- the web driver tries to retrieve the snapshots 3 times before quitting. it will notify you for each failed attempt and stop after the 3rd failure. 
- note that there will be an error pulling the data on the first gameday of each year. this occurs because i pull snapshots from a day *before* the game. so obviously there is no data to successfully pull from before the first game. this does NOT cause any problems. just be aware that you will get the 3 attempt notifications for each year for a date in mid-november.
